### PR TITLE
Corrected "mspid" in connection profile templates to use "-" separator from CN of organization

### DIFF
--- a/playbooks/ops/profilegen/templates/goprofile.j2
+++ b/playbooks/ops/profilegen/templates/goprofile.j2
@@ -35,7 +35,7 @@
 {% for org in allorgs %}
 {%  set orgelements = allkeys.values() | selectattr("org", "equalto", org) | list %}
     "{{ org }}": {
-      "mspid": "{{ org.split('.')|join('') }}",
+      "mspid": "{{ org.split('.')|join('-') }}",
       "cryptoPath": "{{ org }}/users/{username}@{{ org }}/msp",
       "peers": [
 {% for peer in allpeers|selectattr('org', 'equalto', org)|list %}

--- a/playbooks/ops/profilegen/templates/goprofileyaml.j2
+++ b/playbooks/ops/profilegen/templates/goprofileyaml.j2
@@ -45,7 +45,7 @@
 {% for org in allorgs %}
 {%  set orgelements = allkeys.values() | selectattr('org', 'equalto', org) | list %}
   "{{ org }}":
-    "mspid": "{{ org.split('.')|join('') }}"
+    "mspid": "{{ org.split('.')|join('-') }}"
     "cryptoPath": "{{ org }}/users/{username}@{{ org}}/msp"
     "peers":
 {%   for peer in allpeers|selectattr('org', 'equalto', org)|list %}

--- a/playbooks/ops/profilegen/templates/nodeprofile.j2
+++ b/playbooks/ops/profilegen/templates/nodeprofile.j2
@@ -21,7 +21,7 @@
 {%  set orgcas = allcas|selectattr('org', 'equalto', org)|list %}
 {%  set orgelements = allkeys.values() | selectattr("org", "equalto", org) | list %}
     "{{ org }}": {
-      "mspid": "{{ org.split('.')|join('') }}",
+      "mspid": "{{ org.split('.')|join('-') }}",
       "peers": [
 {% for peer in allpeers|selectattr('org', 'equalto', org)|list %}
         "{{ peer.fullname }}"{{ '' if loop.last else ',' }}

--- a/playbooks/ops/profilegen/templates/nodeprofileyaml.j2
+++ b/playbooks/ops/profilegen/templates/nodeprofileyaml.j2
@@ -17,7 +17,7 @@
 {%  set orgcas = allcas|selectattr('org', 'equalto', org)|list %}
 {%  set orgelements = allkeys.values() | selectattr('org', 'equalto', org) | list %}
   "{{ org }}":
-    "mspid": "{{ org.split('.')|join('') }}"
+    "mspid": "{{ org.split('.')|join('-') }}"
     "peers":
 {%  for peer in allpeers|selectattr('org', 'equalto', org)|list %}
     - "{{ peer.fullname }}"


### PR DESCRIPTION
Corrected "mspid" in connection profile templates to use "-" separator from the canonical name of the organization. Example: example.com becomes "example-com" rather than "examplecom" otherwise you will get an error " [DiscoveryService]: send[xxxx] - Channel:xxx received discovery error:access denied"