### PR TITLE
Update ccapprove.j2

### DIFF
--- a/playbooks/ops/templates/ccapprove.j2
+++ b/playbooks/ops/templates/ccapprove.j2
@@ -36,7 +36,7 @@ export CORE_PEER_ADDRESS={{ approvepeer.url }}:{{ approvepeer.port }}
     --collections-config /vars/{{CC_NAME}}_collection_config.json \
 {% endif %}
 {% if CC_POLICY != 'Cg==' %}
-    --signature-policy '{{ CC_POLICY|b64decode|trim }}' \
+    --signature-policy "{{ CC_POLICY|b64decode|trim }}" \
 {% endif %}
     --sequence $SEQUENCE -o $ORDERER_ADDRESS --tls --cafile $ORDERER_TLS_CA
 # fi


### PR DESCRIPTION
same as commit it needs "{{ CC_POLICY|b64decode|trim }}" and not '{{ CC_POLICY|b64decode|trim }}'
peer lifecycle chaincode commit -o $ORDERER_ADDRESS --channelID telerom \
  --name myasset --version 1.0 --sequence $SEQUENCE \
  --peerAddresses 192.168.69.18:7002 \
  --tlsRootCertFiles  \
  --init-required \
  --signature-policy 'AND(org1.example.com.member, org2.example.com.member)' \
  --cafile $ORDERER_TLS_CA --tls

So  --signature-policy 'AND(org1.example.com.member, org2.example.com.member)'  should be  --signature-policy "AND(org1.example.com.member, org2.example.com.member)"