### PR TITLE
Display the spec file being used on starting minifab

### DIFF
--- a/minifab
+++ b/minifab
@@ -2,9 +2,11 @@
 [ ! -d "$(pwd)/vars" ] && mkdir vars
 ADDRS=$(ifconfig|grep 'inet '|grep -v '\.1 '|tr -s ' '|awk '{$1=$1};1'|cut -d ' ' -f 2|cut -d '/' -f 1|paste -sd "," -|sed s/addr://g)
 if [ -f "$(pwd)/spec.yaml" ]; then
+  echo "Using spec file: $(pwd)/spec.yaml"
   docker run --rm --name minifab -v /var/run/docker.sock:/var/run/docker.sock -v $(pwd)/vars:/home/vars \
   -v $(pwd)/spec.yaml:/home/spec.yaml -e "ADDRS=$ADDRS" hfrd/minifab:latest /home/main.sh "$@"
 else
+  echo "Using default spec file"
   docker run --rm --name minifab -v /var/run/docker.sock:/var/run/docker.sock -v $(pwd)/vars:/home/vars \
   -e "ADDRS=$ADDRS" hfrd/minifab:latest /home/main.sh "$@"
 fi

--- a/minifabwin
+++ b/minifabwin
@@ -19,9 +19,11 @@ for /f "usebackq tokens=2 delims=:" %%a in (`ipconfig ^| findstr /r "[0-9][0-9]*
   )
 )
 IF EXIST "%CD%/spec.yaml" (
+  echo Using spec file: %CD%\spec.yaml
   docker run --rm --name minifab -v /var/run/docker.sock:/var/run/docker.sock -v %CD%/vars:/home/vars ^
     -v %CD%/spec.yaml:/home/spec.yaml -e "ADDRS=!_alladdress!" hfrd/minifab:latest /home/main.sh %*
 ) ELSE (
+  echo Using default spec file
   docker run --rm --name minifab -v /var/run/docker.sock:/var/run/docker.sock -v %CD%/vars:/home/vars ^
     -e "ADDRS=!_alladdress!" hfrd/minifab:latest /home/main.sh %*
 )


### PR DESCRIPTION
This PR simply changes the main minifab script files to display the spec file being used.

Signed-off-by: Arnaud J Le Hors <lehors@us.ibm.com>