### PR TITLE
Make discover cmd output endorsers and orderers config file paths

### DIFF
--- a/playbooks/ops/discover/apply.yaml
+++ b/playbooks/ops/discover/apply.yaml
@@ -56,8 +56,9 @@
       dest: "{{ pjroot }}/vars/discover/{{ CHANNEL_NAME}}/ordererendpoints.json"
       content: >-
         {{ channel_cfg.orderers | to_nice_json(indent=2) }}
+    register: orderers_copy
 
-  - name: Remove the temparary file
+  - name: Remove the temporary file
     command: "rm -rf {{ pjroot }}/vars/discover/{{ CHANNEL_NAME }}_config.json"
 
 - name: Check if channel chaincode endorser config exists
@@ -65,8 +66,20 @@
     path: "{{ pjroot }}/vars/discover/{{ CHANNEL_NAME }}_{{ CC_NAME }}_endorsers.json"
   register: exflag
 
-- name: Remove the temparary file
+- name: Remove the temporary file
   when: exflag.stat.exists == true
   command: >-
     mv {{ pjroot }}/vars/discover/{{ CHANNEL_NAME }}_{{ CC_NAME }}_endorsers.json
     {{ pjroot }}/vars/discover/{{ CHANNEL_NAME }}/{{ CC_NAME }}_endorsers.json
+
+- name: Discover endorsers results
+  when: exflag.stat.exists == true
+  debug:
+    msg: "Chaincode endorsers file: ./vars/discover/{{ CHANNEL_NAME }}/{{ CC_NAME }}_endorsers.json"
+  tags: [print_action]
+
+- name: Discover orderers results
+  when: orderers_copy.failed == false
+  debug:
+    msg: "Channel orderers file: ./vars/discover/{{ CHANNEL_NAME }}/ordererendpoints.json"
+  tags: [print_action]

--- a/playbooks/ops/templates/discover.j2
+++ b/playbooks/ops/templates/discover.j2
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Script to instantiate chaincode
+# Script to discover endorsers and channel config
 cd /vars
 
 export PEER_TLS_ROOTCERT_FILE=/vars/keyfiles/peerOrganizations/{{ actingpeer.org }}/users/Admin@{{ actingpeer.org }}/tls/ca.crt


### PR DESCRIPTION
With this change the discover command outputs the path of the files it created, making it easier for the user to find them.

```
# Discover endorsers results **********************************
  Chaincode endorsers file: ./vars/discover/mychannel/simple_endorsers.json
# Discover orderers results ***********************************
  Channel orderers file: ./vars/discover/mychannel/ordererendpoints.json

```
Signed-off-by: Arnaud J Le Hors <lehors@us.ibm.com>